### PR TITLE
Update temper.py

### DIFF
--- a/temper.py
+++ b/temper.py
@@ -60,8 +60,7 @@ class USBList(object):
     Return these names in a set.
     '''
     devices = set()
-    with os.scandir(dirname) as it:
-      for entry in it:
+    for entry in os.scandir(dirname):
         if entry.is_dir() and not entry.is_symlink():
           devices |= self._find_devices(os.path.join(dirname, entry.name))
         if re.search('tty.*[0-9]', entry.name):
@@ -96,8 +95,7 @@ class USBList(object):
     USB devices on a system. Return these as a dictionary indexed by the path.
     '''
     info = dict()
-    with os.scandir(Temper.SYSPATH) as it:
-      for entry in it:
+    for entry in os.scandir(Temper.SYSPATH):
         if entry.is_dir():
           path = os.path.join(Temper.SYSPATH, entry.name)
           device = self._get_usb_device(path)


### PR DESCRIPTION
"with" keyword cannot be use with os.scandir in python3.5.2 , this should work for all python3