### PR TITLE
Fix issues from #9 -- increase select time, replace invalid firmware string

### DIFF
--- a/temper.py
+++ b/temper.py
@@ -29,7 +29,6 @@ import re
 import select
 import struct
 import sys
-from time import sleep
 from warnings import warn
 
 # Non-standard modules
@@ -151,14 +150,8 @@ class USBRead(object):
     os.write(fd, struct.pack('8B', 0x01, 0x86, 0xff, 0x01, 0, 0, 0, 0))
     firmware = b''
 
-    # Hardware Quirk:
-    # This hardware is sluggish to respond, or some other race condition
-    # exists.  This works around that.
-    if self.vendorid == 0x413d and self.productid == 0x2107:
-      sleep(0.1)  # 0.05 isn't enough!  Hardware is made of glue and spit.
-
     while True:
-      r, _, _ = select.select([fd], [], [], 0.1)
+      r, _, _ = select.select([fd], [], [], 0.2)
       if fd not in r:
         break
       data = os.read(fd, 8)


### PR DESCRIPTION
The `select` call has been increased to ~`0.2`~  `0.5` seconds, which stops the issue originally mentioned in #9 - "Cannot read firmware from device".

A second issue is brought up in #9 - Sometimes the returned firmware string is `V3.3` instead of `TEMPerX_V3.3`.  This workaround simply ~replaces `V3.3` with the full `TEMPerX_V3.3` string~ retries when the `V3.3` string is encountered.

~When the replacement is used, a warning is issued.  This goes to stderr, and doesn't interfere with piping the output of the script.~

#### Reproduction
If you haven't applied the fix yet and are attempting to verify the bug's existence:

* use the TEMPer2 device
* `413d:2107` vendor/product ids
* `TEMPerX_V3.3`
* internal and external temperature sensors
* executing `temper.py` once a second causes the issue to be much more frequent
* Raspberry pi 3b -- issues may also occur with other hardware, but this is what I'm testing on.

#### Example
Using xonsh:

```python
import time

while True:
    ./temper.py
    time.sleep(1)
````

