### PR TITLE
Added support to TEMPer1V1.1 (TEMPer1F1.1Per1F)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@ temper.py.
 In the following table "I" means the sensor is internal to the USB stick and
 "E" means the sensor is on a cable that is plugged into the USB stick.
 
-Product    |    Id     |  Firmware       | Temp | Hum | Notes
------------|-----------|-----------------|------|-----|---------------
-TEMPer     | 0c45:7401 | TEMPerF1.4      | I    |     | Metal
-TEMPer     | 413d:2107 | TEMPerGold_V3.1 | I    |     | Metal
-TEMPerHUM  | 413d:2107 | TEMPerX_V3.1    | I    | I   | White plastic
-TEMPer2    | 413d:2107 | TEMPerX_V3.3    | I,E  |     | White plastic
-TEMPer1F   | 413d:2107 | TEMPerX_V3.3    | E    |     | White plastic
-TEMPerX232 | 1a86:5523 | TEMPerX232_V2.0 | I,E  | I   | White plastic
+Product     |    Id     |  Firmware        | Temp | Hum | Notes
+------------|-----------|------------------|------|-----|---------------
+TEMPer      | 0c45:7401 | TEMPerF1.4       | I    |     | Metal
+TEMPer      | 413d:2107 | TEMPerGold_V3.1  | I    |     | Metal
+TEMPerHUM   | 413d:2107 | TEMPerX_V3.1     | I    | I   | White plastic
+TEMPer2     | 413d:2107 | TEMPerX_V3.3     | I,E  |     | White plastic
+TEMPer1F    | 413d:2107 | TEMPerX_V3.3     | E    |     | White plastic
+TEMPerX232  | 1a86:5523 | TEMPerX232_V2.0  | I,E  | I   | White plastic
+TEMPer1V1.1 | 0c45:7401 | TEMPer1F1.1Per1F | E    |     | Metal
 
 The 1a86:5523 device may identify as 413d:2107 depending on button presses,
 but it cannot be used successfully when in that mode.

--- a/temper.py
+++ b/temper.py
@@ -195,7 +195,7 @@ class USBRead(object):
     info['hex_firmware'] = str(binascii.b2a_hex(firmware), 'latin-1')
     info['hex_data'] = str(binascii.b2a_hex(bytes), 'latin-1')
 
-    if info['firmware'][:10] == 'TEMPerF1.4':
+    if info['firmware'][:10] in [ 'TEMPerF1.4', 'TEMPer1F1.' ]:
       info['firmware'] = info['firmware'][:10]
       self._parse_bytes('internal temperature', 2, 256.0, bytes, info)
       return info


### PR DESCRIPTION
Before:
```
$ ./temper.py -l
...
Bus 004 Dev 002 0c45:7401 * TEMPer1V1.1 ['hidraw0', 'hidraw1']

$ ./temper.py --json
[
    {
        "vendorid": 3141,
        "productid": 29697,
        "manufacturer": "RDing",
        "product": "TEMPer1V1.1",
        "busnum": 4,
        "devnum": 2,
        "devices": [
            "hidraw0",
            "hidraw1"
        ],
        "firmware": "TEMPer1F1.1Per1F",
        "hex_firmware": "54454d5065723146312e315065723146",
        "hex_data": "8002135065723146",
        "error": "Unknown firmware TEMPer1F1.1Per1F: b'8002135065723146'"
    }
]

$ ./temper.py --json --verbose
Firmware query: b'0186ff0100000000'
Firmware value: b'54454d5065723146312e315065723146' TEMPer1F1.1Per1F
Data value: b'8002135065723146'
[
    {
        "vendorid": 3141,
        "productid": 29697,
        "manufacturer": "RDing",
        "product": "TEMPer1V1.1",
        "busnum": 4,
        "devnum": 2,
        "devices": [
            "hidraw0",
            "hidraw1"
        ],
        "firmware": "TEMPer1F1.1Per1F",
        "hex_firmware": "54454d5065723146312e315065723146",
        "hex_data": "8002135065723146",
        "error": "Unknown firmware TEMPer1F1.1Per1F: b'8002135065723146'"
    }
]
```

After the change:

```
$ ./temper.py 
Bus 004 Dev 002 0c45:7401 TEMPer1F1. 19.31C 66.76F - - - -

$ ./temper.py --json
[
    {
        "vendorid": 3141,
        "productid": 29697,
        "manufacturer": "RDing",
        "product": "TEMPer1V1.1",
        "busnum": 4,
        "devnum": 2,
        "devices": [
            "hidraw0",
            "hidraw1"
        ],
        "firmware": "TEMPer1F1.",
        "hex_firmware": "54454d5065723146312e315065723146",
        "hex_data": "8002135065723146",
        "internal temperature": 19.3125
    }
]

$ ./temper.py --json --verbose
Firmware query: b'0186ff0100000000'
Firmware value: b'54454d5065723146312e315065723146' TEMPer1F1.1Per1F
Data value: b'8002135065723146'
[
    {
        "vendorid": 3141,
        "productid": 29697,
        "manufacturer": "RDing",
        "product": "TEMPer1V1.1",
        "busnum": 4,
        "devnum": 2,
        "devices": [
            "hidraw0",
            "hidraw1"
        ],
        "firmware": "TEMPer1F1.",
        "hex_firmware": "54454d5065723146312e315065723146",
        "hex_data": "8002135065723146",
        "internal temperature": 19.3125
    }
]
```