### PR TITLE
Add support for TEMPer devices with TEMPerGold_V3.3  firmware (id 1a86:e025)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Product    |    Id     |  Firmware       | Temp | Hum | Notes
 -----------|-----------|-----------------|------|-----|---------------
 TEMPer     | 0c45:7401 | TEMPerF1.4      | I    |     | Metal
 TEMPer     | 413d:2107 | TEMPerGold_V3.1 | I    |     | Metal
+TEMPer     | 0409:0059 | TEMPerGold_V3.3 | I    |     | Metal
 TEMPerHUM  | 413d:2107 | TEMPerX_V3.1    | I    | I   | White plastic
 TEMPer2    | 413d:2107 | TEMPerX_V3.3    | I,E  |     | White plastic
 TEMPer1F   | 413d:2107 | TEMPerX_V3.3    | E    |     | White plastic

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Product    |    Id     |  Firmware       | Temp | Hum | Notes
 -----------|-----------|-----------------|------|-----|---------------
 TEMPer     | 0c45:7401 | TEMPerF1.4      | I    |     | Metal
 TEMPer     | 413d:2107 | TEMPerGold_V3.1 | I    |     | Metal
-TEMPer     | 0409:0059 | TEMPerGold_V3.3 | I    |     | Metal
+TEMPer     | 1a86:e025 | TEMPerGold_V3.3 | I    |     | Metal
 TEMPerHUM  | 413d:2107 | TEMPerX_V3.1    | I    | I   | White plastic
 TEMPer2    | 413d:2107 | TEMPerX_V3.3    | I,E  |     | White plastic
 TEMPer1F   | 413d:2107 | TEMPerX_V3.3    | E    |     | White plastic

--- a/temper.py
+++ b/temper.py
@@ -297,7 +297,7 @@ class Temper(object):
       return True
     if vendorid == 0x1a86 and productid == 0x5523:
       return True
-    if vendorid == 0x0409 and productid == 0x0059:
+    if vendorid == 0x1a86 and productid == 0xe025:
       return True
 
     # The id is not known to this program.

--- a/temper.py
+++ b/temper.py
@@ -200,7 +200,7 @@ class USBRead(object):
       self._parse_bytes('internal temperature', 2, 256.0, bytes, info)
       return info
 
-    if info['firmware'][:15] == 'TEMPerGold_V3.1':
+    if info['firmware'][:15] == 'TEMPerGold_V3.1' or info['firmware'][:15] == 'TEMPerGold_V3.3':
       info['firmware'] = info['firmware'][:15]
       self._parse_bytes('internal temperature', 2, 100.0, bytes, info)
       return info
@@ -296,6 +296,8 @@ class Temper(object):
     if vendorid == 0x413d and productid == 0x2107:
       return True
     if vendorid == 0x1a86 and productid == 0x5523:
+      return True
+    if vendorid == 0x0409 and productid == 0x0059:
       return True
 
     # The id is not known to this program.


### PR DESCRIPTION
I recently bought a classic TEMPer device (one of these with the metal cases) [from Amazon](https://www.amazon.de/-/en/gp/product/B07BFBSF57/ref=ppx_yo_dt_b_asin_title_o05_s00?ie=UTF8&psc=1), and it turned out to have 0409:0059 as a product ID and use the TEMPerGold_V3.3 firmware. I added support for this to temper.py and added the device to the table in the README.